### PR TITLE
update to support pydantic 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-notion-client>=0.8.0
-pydantic~=1.9.0
-pandas 
-dataclasses
+notion-client~=2.2.1
+pandas~=2.0.2
+dataclasses~=0.6
+pydantic~=2.9.2

--- a/src/notion_df/base.py
+++ b/src/notion_df/base.py
@@ -1,6 +1,6 @@
 from typing import List, Dict, Optional, Any
 from enum import Enum
-from pydantic import BaseModel, validator, root_validator
+from pydantic import field_validator, BaseModel, root_validator
 import pandas as pd
 
 from notion_df.utils import is_time_string, is_uuid
@@ -51,15 +51,16 @@ class RichTextTypeEnum(str, Enum):
 
 
 class SelectOption(BaseModel):
-    id: Optional[str]
+    id: Optional[str] = None
     name: str
-    color: Optional[NotionColorEnum]
+    color: Optional[NotionColorEnum] = None
 
     @classmethod
     def from_value(cls, value: str):
         return cls(name=value)
 
-    @validator("name")
+    @field_validator("name")
+    @classmethod
     def name_cannot_contain_comma(cls, v):
         if "," in v:
             raise ValueError(f"Invalid option name {v} that contains comma")
@@ -67,7 +68,7 @@ class SelectOption(BaseModel):
 
 
 class SelectOptions(BaseModel):
-    options: Optional[List[SelectOption]]
+    options: Optional[List[SelectOption]] = None
 
     @classmethod
     def from_value(cls, values: List[str]):
@@ -82,7 +83,8 @@ class RelationObject(BaseModel):
     def from_value(cls, value: str):
         return cls(id=value)
 
-    @validator("id")
+    @field_validator("id")
+    @classmethod
     def id_must_be_uuid(cls, v):
         if not is_uuid(v):
             raise ValueError(f"Invalid id {v}")
@@ -92,15 +94,16 @@ class RelationObject(BaseModel):
 class UserObject(BaseModel):
     object: str = "user"
     id: str
-    type: Optional[str]
-    name: Optional[str]
-    avatar_url: Optional[str]
+    type: Optional[str] = None
+    name: Optional[str] = None
+    avatar_url: Optional[str] = None
 
     @classmethod
     def from_value(cls, value: str):
         return cls(id=value)
 
-    @validator("object")
+    @field_validator("object")
+    @classmethod
     def object_is_name(cls, v):
         if v != "user":
             raise ValueError(f"Invalid user object value {v}")
@@ -122,8 +125,8 @@ class FormulaProperty(BaseModel):
 class RelationProperty(BaseModel):
     database_id: str
     # TODO: Change this to UUID validation
-    synced_property_name: Optional[str]
-    synced_property_id: Optional[str]
+    synced_property_name: Optional[str] = None
+    synced_property_id: Optional[str] = None
 
 
 class DateObject(BaseModel):
@@ -131,7 +134,8 @@ class DateObject(BaseModel):
     end: Optional[str] = None
     time_zone: Optional[str] = None
 
-    @validator("start")
+    @field_validator("start")
+    @classmethod
     def is_start_ISO8601(cls, v):
         # TODO: Currently it cannot suport time ranges
         if v is not None:
@@ -141,7 +145,8 @@ class DateObject(BaseModel):
                 )
         return v
 
-    @validator("end")
+    @field_validator("end")
+    @classmethod
     def is_end_ISO8601(cls, v):
         if v is not None:
             if not is_time_string(v):
@@ -163,10 +168,10 @@ class DateObject(BaseModel):
 
 
 class RollupProperty(BaseModel):
-    relation_property_name: Optional[str]
-    relation_property_id: Optional[str]
-    rollup_property_name: Optional[str]
-    rollup_property_id: Optional[str]
+    relation_property_name: Optional[str] = None
+    relation_property_id: Optional[str] = None
+    rollup_property_name: Optional[str] = None
+    rollup_property_id: Optional[str] = None
     function: str
     # TODO: Change this to ENUM - https://developers.notion.com/reference/create-a-database#rollup-configuration
 
@@ -174,19 +179,20 @@ class RollupProperty(BaseModel):
 class RollupObject(BaseModel):
     type: str
     # TODO: Change this to ENUM - https://developers.notion.com/reference/property-value-object#rollup-property-values
-    number: Optional[float]
-    date: Optional[DateObject]
-    array: Optional[List[Any]]
+    number: Optional[float] = None
+    date: Optional[DateObject] = None
+    array: Optional[List[Any]] = None
     # Based on the description in https://developers.notion.com/reference/property-value-object#rollup-property-value-element
     # Each element is exactly like property value object, but without the "id" key.
     # As there's a preprocess step in RollupValues, each item of the array must
     # be a property value object.
-    function: Optional[str]
+    function: Optional[str] = None
     # Though the function param doesn't appear in the documentation, it exists
     # in the return values of the API. Set it as optional for future compatibility.
     # TODO: check in the future if the function param should be updated.
 
-    @validator("type")
+    @field_validator("type")
+    @classmethod
     def ensure_non_empty_data(cls, v):
         data_type = v
         if data_type is None:
@@ -208,7 +214,7 @@ class RollupObject(BaseModel):
 
 class FileTargetObject(BaseModel):
     url: str
-    expiry_time: Optional[str]
+    expiry_time: Optional[str] = None
 
     @property
     def value(self):
@@ -216,10 +222,10 @@ class FileTargetObject(BaseModel):
 
 
 class FileObject(BaseModel):
-    name: Optional[str] #TODO: Figure out why this is not required...
+    name: Optional[str] = None #TODO: Figure out why this is not required...
     type: str
-    file: Optional[FileTargetObject]
-    external: Optional[FileTargetObject]
+    file: Optional[FileTargetObject] = None
+    external: Optional[FileTargetObject] = None
 
     @property
     def value(self):
@@ -233,10 +239,10 @@ class FileObject(BaseModel):
 
 class FormulaObject(BaseModel):
     type: str
-    string: Optional[str]
-    number: Optional[float]
-    boolean: Optional[bool]
-    date: Optional[DateObject]
+    string: Optional[str] = None
+    number: Optional[float] = None
+    boolean: Optional[bool] = None
+    date: Optional[DateObject] = None
 
     @property
     def value(self):
@@ -267,7 +273,7 @@ class TextLinkObject(BaseModel):
 
 class TextObject(BaseModel):
     content: str
-    link: Optional[TextLinkObject]
+    link: Optional[TextLinkObject] = None
 
 
 class PageReferenceObject(BaseModel):
@@ -280,11 +286,11 @@ class LinkPreviewMentionObject(BaseModel):
 
 class MentionObject(BaseModel):
     type: str
-    user: Optional[UserObject]
-    page: Optional[PageReferenceObject]
-    database: Optional[PageReferenceObject]
-    date: Optional[DateObject]
-    link_preview: Optional[LinkPreviewMentionObject]
+    user: Optional[UserObject] = None
+    page: Optional[PageReferenceObject] = None
+    database: Optional[PageReferenceObject] = None
+    date: Optional[DateObject] = None
+    link_preview: Optional[LinkPreviewMentionObject] = None
 
 
 class EquationObject(BaseModel):
@@ -292,11 +298,11 @@ class EquationObject(BaseModel):
 
 
 class BaseRichTextObject(BaseModel):
-    plain_text: Optional[str]
+    plain_text: Optional[str] = None
     # TODO: The Optional[plain_text] is used when creating property values
     href: Optional[str] = None
     annotations: Optional[AnnotationObject] = None
-    type: Optional[RichTextTypeEnum]
+    type: Optional[RichTextTypeEnum] = None
 
     @property
     def value(self):
@@ -304,9 +310,9 @@ class BaseRichTextObject(BaseModel):
 
 
 class RichTextObject(BaseRichTextObject):
-    text: Optional[TextObject]
-    mention: Optional[MentionObject]
-    equation: Optional[EquationObject]
+    text: Optional[TextObject] = None
+    mention: Optional[MentionObject] = None
+    equation: Optional[EquationObject] = None
 
     @classmethod
     def from_value(cls, value: str):

--- a/src/notion_df/blocks.py
+++ b/src/notion_df/blocks.py
@@ -20,10 +20,10 @@ from notion_df.base import (
 
 class ParentObject(BaseModel):
     type: str
-    database_id: Optional[str]
-    page_id: Optional[str]
-    workspace: Optional[bool]
-    block_id: Optional[str]
+    database_id: Optional[str] = None
+    page_id: Optional[str] = None
+    workspace: Optional[bool] = None
+    block_id: Optional[str] = None
 
 
 # BaseClasses
@@ -32,37 +32,37 @@ class BaseAttributes(BaseModel):
 
 
 class BaseAttributeWithChildren(BaseModel):
-    children: Optional[List["BaseNotionBlock"]]
+    children: Optional[List["BaseNotionBlock"]] = None
 
 
 class TextBlockAttributes(BaseAttributeWithChildren):
     rich_text: List[RichTextObject]
-    color: Optional[NotionExtendedColorEnum]
+    color: Optional[NotionExtendedColorEnum] = None
 
 
 class HeadingBlockAttributes(BaseAttributeWithChildren):
     rich_text: List[RichTextObject]
-    color: Optional[NotionExtendedColorEnum]
+    color: Optional[NotionExtendedColorEnum] = None
     is_toggleable: bool
     # Whether or not the heading block is a toggle heading or not. If true, the heading block has toggle and can support children. If false, the heading block is a normal heading block.
 
 
 class CalloutBlockAttributes(BaseAttributeWithChildren):
     rich_text: List[RichTextObject]
-    icon: Optional[Union[FileObject, EmojiObject]]
-    color: Optional[NotionExtendedColorEnum]
+    icon: Optional[Union[FileObject, EmojiObject]] = None
+    color: Optional[NotionExtendedColorEnum] = None
 
 
 class ToDoBlockAttributes(BaseAttributeWithChildren):
     rich_text: List[RichTextObject]
-    color: Optional[NotionExtendedColorEnum]
-    checked: Optional[bool]
+    color: Optional[NotionExtendedColorEnum] = None
+    checked: Optional[bool] = None
 
 
 class CodeBlockAttributes(BaseAttributes):
     rich_text: List[RichTextObject]
-    caption: Optional[List[RichTextObject]]
-    language: Optional[str]  # TODO: it's actually an enum
+    caption: Optional[List[RichTextObject]] = None
+    language: Optional[str] = None  # TODO: it's actually an enum
 
 
 class ChildPageAttributes(BaseAttributes):
@@ -74,7 +74,7 @@ class EmbedBlockAttributes(BaseAttributes):
 
 
 class ImageBlockAttributes(BaseAttributes, FileObject):
-    caption: Optional[List[RichTextObject]]
+    caption: Optional[List[RichTextObject]] = None
     # This is not listed in the docs, but it is in the API response (Nov 2022)
 
 
@@ -84,7 +84,7 @@ class VideoBlockAttributes(BaseAttributes):
 
 class FileBlockAttributes(BaseAttributes):
     file: FileObject
-    caption: Optional[List[RichTextObject]]
+    caption: Optional[List[RichTextObject]] = None
 
 
 class PdfBlockAttributes(BaseAttributes):
@@ -93,7 +93,7 @@ class PdfBlockAttributes(BaseAttributes):
 
 class BookmarkBlockAttributes(BaseAttributes):
     url: str
-    caption: Optional[List[RichTextObject]]
+    caption: Optional[List[RichTextObject]] = None
 
 
 class EquationBlockAttributes(BaseAttributes):
@@ -101,7 +101,7 @@ class EquationBlockAttributes(BaseAttributes):
 
 
 class TableOfContentsAttributes(BaseAttributes):
-    color: Optional[NotionExtendedColorEnum]
+    color: Optional[NotionExtendedColorEnum] = None
 
 
 class LinkPreviewAttributes(BaseAttributes):
@@ -110,8 +110,8 @@ class LinkPreviewAttributes(BaseAttributes):
 
 class LinkToPageAttributes(BaseAttributes):
     type: str
-    page_id: Optional[str]
-    database_id: Optional[str]
+    page_id: Optional[str] = None
+    database_id: Optional[str] = None
 
 
 ATTRIBUTES_MAPPING = {
@@ -123,15 +123,15 @@ ATTRIBUTES_MAPPING = {
 
 class BaseNotionBlock(BaseModel):
     object: str = "block"
-    parent: Optional[ParentObject]
-    id: Optional[str]
-    type: Optional[str]
-    created_time: Optional[str]
+    parent: Optional[ParentObject] = None
+    id: Optional[str] = None
+    type: Optional[str] = None
+    created_time: Optional[str] = None
     # created_by
-    last_edited_time: Optional[str]
+    last_edited_time: Optional[str] = None
     # created_by
-    has_children: Optional[bool]
-    archived: Optional[bool]
+    has_children: Optional[bool] = None
+    archived: Optional[bool] = None
     type: str
 
     @property
@@ -244,7 +244,7 @@ class EquationBlock(BaseNotionBlock):
 
 class DividerBlock(BaseNotionBlock):
     type: str = "divider"
-    divider: Optional[Dict]
+    divider: Optional[Dict] = None
 
 
 class TableOfContentsBlock(BaseNotionBlock):
@@ -254,7 +254,7 @@ class TableOfContentsBlock(BaseNotionBlock):
 
 class BreadcrumbBlock(BaseNotionBlock):
     type: str = "breadcrumb"
-    breadcrumb: Optional[Dict]
+    breadcrumb: Optional[Dict] = None
 
 
 # TODO: Column List and Column Blocks

--- a/src/notion_df/configs.py
+++ b/src/notion_df/configs.py
@@ -3,7 +3,7 @@ import warnings
 import itertools
 from dataclasses import dataclass
 
-from pydantic import BaseModel, validator, parse_obj_as
+from pydantic import field_validator, BaseModel, validator, parse_obj_as
 from pandas.api.types import (
     is_datetime64_any_dtype,
     is_numeric_dtype,
@@ -32,12 +32,14 @@ from notion_df.utils import (
 
 
 class BasePropertyConfig(BaseModel):
-    id: Optional[str]
-    type: Optional[str]
+    id: Optional[str] = None
+    type: Optional[str] = None
 
     def query_dict(self):
         return flatten_dict(self.dict())
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("type", always=True)
     def automatically_set_type_value(cls, v):
         _type = list(cls.__fields__.keys())[-1]
@@ -52,7 +54,8 @@ class TitleConfig(BasePropertyConfig):
     title: Dict = {}
 
     # TODO: Make the validator automatically geneerated
-    @validator("title")
+    @field_validator("title")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The title dict must be empty")
@@ -62,7 +65,8 @@ class TitleConfig(BasePropertyConfig):
 class RichTextConfig(BasePropertyConfig):
     rich_text: Dict = {}
 
-    @validator("rich_text")
+    @field_validator("rich_text")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The rich_text dict must be empty")
@@ -76,17 +80,18 @@ class NumberConfig(BasePropertyConfig):
 
 
 class SelectConfig(BasePropertyConfig):
-    select: Optional[SelectOptions]
+    select: Optional[SelectOptions] = None
 
 
 class MultiSelectConfig(BasePropertyConfig):
-    multi_select: Optional[SelectOptions]
+    multi_select: Optional[SelectOptions] = None
 
 
 class DateConfig(BasePropertyConfig):
     date: Dict = {}
 
-    @validator("date")
+    @field_validator("date")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The date dict must be empty")
@@ -96,7 +101,8 @@ class DateConfig(BasePropertyConfig):
 class PeopleConfig(BasePropertyConfig):
     people: Dict = {}
 
-    @validator("people")
+    @field_validator("people")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The people dict must be empty")
@@ -106,7 +112,8 @@ class PeopleConfig(BasePropertyConfig):
 class FilesConfig(BasePropertyConfig):
     files: Dict = {}
 
-    @validator("files")
+    @field_validator("files")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The files dict must be empty")
@@ -116,7 +123,8 @@ class FilesConfig(BasePropertyConfig):
 class CheckboxConfig(BasePropertyConfig):
     checkbox: Dict = {}
 
-    @validator("checkbox")
+    @field_validator("checkbox")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The checkbox dict must be empty")
@@ -126,7 +134,8 @@ class CheckboxConfig(BasePropertyConfig):
 class URLConfig(BasePropertyConfig):
     url: Dict = {}
 
-    @validator("url")
+    @field_validator("url")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The url dict must be empty")
@@ -136,7 +145,8 @@ class URLConfig(BasePropertyConfig):
 class EmailConfig(BasePropertyConfig):
     email: Dict = {}
 
-    @validator("email")
+    @field_validator("email")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The email dict must be empty")
@@ -146,7 +156,8 @@ class EmailConfig(BasePropertyConfig):
 class PhoneNumberConfig(BasePropertyConfig):
     phone_number: Dict = {}
 
-    @validator("phone_number")
+    @field_validator("phone_number")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The phone_number dict must be empty")
@@ -168,7 +179,8 @@ class RollupConfig(BasePropertyConfig):
 class CreatedTimeConfig(BasePropertyConfig):
     created_time: Dict = {}
 
-    @validator("created_time")
+    @field_validator("created_time")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The created_time dict must be empty")
@@ -178,7 +190,8 @@ class CreatedTimeConfig(BasePropertyConfig):
 class CreatedByConfig(BasePropertyConfig):
     created_by: Dict = {}
 
-    @validator("created_by")
+    @field_validator("created_by")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The created_by dict must be empty")
@@ -188,7 +201,8 @@ class CreatedByConfig(BasePropertyConfig):
 class LastEditedTimeConfig(BasePropertyConfig):
     last_edited_time: Dict = {}
 
-    @validator("last_edited_time")
+    @field_validator("last_edited_time")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The last_edited_time dict must be empty")
@@ -198,7 +212,8 @@ class LastEditedTimeConfig(BasePropertyConfig):
 class LastEditedByConfig(BasePropertyConfig):
     last_edited_by: Dict = {}
 
-    @validator("last_edited_by")
+    @field_validator("last_edited_by")
+    @classmethod
     def title_is_empty_dict(cls, v):
         if v:
             raise ValueError("The last_edited_by dict must be empty")

--- a/src/notion_df/values.py
+++ b/src/notion_df/values.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from copy import deepcopy
 import numbers
 
-from pydantic import BaseModel, parse_obj_as, validator, root_validator
+from pydantic import field_validator, BaseModel, parse_obj_as, root_validator
 import pandas as pd
 from pandas.api.types import is_array_like
 
@@ -26,9 +26,9 @@ from notion_df.utils import (
 
 
 class BasePropertyValues(BaseModel):
-    id: Optional[str]  # TODO: Rethink whether we can do this
+    id: Optional[str] = None  # TODO: Rethink whether we can do this
     # The Optional[id] is used when creating property values
-    type: Optional[str]
+    type: Optional[str] = None
 
     # TODO: Add abstractmethods for them
     @classmethod
@@ -77,7 +77,7 @@ class RichTextValues(BasePropertyValues):
 
 
 class NumberValues(BasePropertyValues):
-    number: Optional[Union[float, int]]
+    number: Optional[Union[float, int]] = None
 
     @property
     def value(self) -> str:
@@ -89,7 +89,7 @@ class NumberValues(BasePropertyValues):
 
 
 class SelectValues(BasePropertyValues):
-    select: Optional[SelectOption]
+    select: Optional[SelectOption] = None
 
     @property
     def value(self) -> Optional[str]:
@@ -118,7 +118,7 @@ class MultiSelectValues(BasePropertyValues):
 
 
 class DateValues(BasePropertyValues):
-    date: Optional[DateObject]
+    date: Optional[DateObject] = None
 
     @property
     def value(self) -> str:
@@ -175,7 +175,7 @@ class FilesValues(BasePropertyValues):
         return [file.value for file in self.files]
 
 class CheckboxValues(BasePropertyValues):
-    checkbox: Optional[bool]
+    checkbox: Optional[bool] = None
 
     @property
     def value(self) -> Optional[bool]:
@@ -187,7 +187,7 @@ class CheckboxValues(BasePropertyValues):
 
 
 class URLValues(BasePropertyValues):
-    url: Optional[str]
+    url: Optional[str] = None
 
     @property
     def value(self) -> Optional[str]:
@@ -206,7 +206,7 @@ class URLValues(BasePropertyValues):
 
 
 class EmailValues(BasePropertyValues):
-    email: Optional[str]
+    email: Optional[str] = None
 
     @property
     def value(self) -> Optional[str]:
@@ -218,7 +218,7 @@ class EmailValues(BasePropertyValues):
 
 
 class PhoneNumberValues(BasePropertyValues):
-    phone_number: Optional[str]
+    phone_number: Optional[str] = None
 
     @property
     def value(self) -> Optional[str]:
@@ -230,7 +230,7 @@ class PhoneNumberValues(BasePropertyValues):
 
 
 class CreatedTimeValues(BasePropertyValues):
-    created_time: Optional[str]
+    created_time: Optional[str] = None
 
     @property
     def value(self) -> Optional[str]:
@@ -280,7 +280,8 @@ VALUES_MAPPING = {
 class RollupValues(BasePropertyValues):
     rollup: RollupObject
 
-    @validator("rollup", pre=True)
+    @field_validator("rollup", mode="before")
+    @classmethod
     def check_rollup_values(cls, val):
         val = deepcopy(val)
         if val.get("array") is not None:


### PR DESCRIPTION
Pydantic 2.0 has breaking changes, namely in the way it handles Optional. Optional values now raise Error if a default value is not provided. This PR migrates to Pedantic 2.0 and supports the Optional types (https://docs.pydantic.dev/latest/migration/) 